### PR TITLE
Fix: Add vercel.json for SPA routing support

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## Problem

When accessing any URL other than `/` directly on the deployed Vercel app, users encounter a 404 error:
```
404: NOT_FOUND 
Code: NOT_FOUND 
ID: dxb1::6mdrr-1748962800305-78df53bcd47b
```

This happens because:
- The app uses React Router with client-side routing
- Vercel's server tries to find physical files for routes like `/roadmap/123`
- Since these files don't exist (they're handled by React Router), Vercel returns 404
- Local development works because Vite dev server automatically serves `index.html` for all routes

## Solution

Added `vercel.json` configuration file that tells Vercel to:
- Serve `index.html` for any request that doesn't match a static file
- Allow React Router to handle routing on the client side

## Changes

- ✅ Added `vercel.json` with rewrite rules for SPA support
- ✅ Fixes direct URL access to all routes (`/roadmap/123`, `/login`, `/signup`, etc.)
- ✅ Enables browser refresh functionality on any route
- ✅ Allows sharing of direct URLs to specific roadmaps

## Testing

After merging and deployment:
1. Direct access to `/roadmap/[id]` should work
2. Browser refresh on any route should work
3. All existing functionality should remain intact

## Files Changed

- `vercel.json` (new file) - Vercel configuration for SPA routing support

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author