### PR TITLE
Fix Firestore timestamp handling in roadmap date display

### DIFF
--- a/src/components/roadmap/RoadmapHistory.jsx
+++ b/src/components/roadmap/RoadmapHistory.jsx
@@ -5,8 +5,17 @@ import { ErrorTooltip } from "../tooltips/EnhancedTooltip";
 const RoadmapHistory = ({ roadmaps, onSelectRoadmap, onDeleteRoadmap }) => {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(null);
 
-  const formatDate = (dateString) => {
-    const date = new Date(dateString);
+  const formatDate = (timestamp) => {
+    if (!timestamp) return 'Unknown';
+
+    // Handle Firestore timestamp objects
+    const date = timestamp.toDate ? timestamp.toDate() : new Date(timestamp);
+
+    // Check if date is valid
+    if (isNaN(date.getTime())) {
+      return 'Invalid Date';
+    }
+
     const now = new Date();
     const diffTime = Math.abs(now - date);
     const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));


### PR DESCRIPTION
## 🐛 Bug Fix

This PR fixes the "Invalid Date" issue in roadmap cards that was occurring after the recent Firestore integration.

### 🔍 Problem
**Issue**: Roadmap cards were displaying "Invalid Date" instead of proper creation dates
**Root Cause**: The `formatDate` function in `RoadmapHistory.jsx` was trying to parse Firestore timestamp objects as regular JavaScript dates

### 🔧 Solution
Updated the `formatDate` function to properly handle Firestore timestamp objects:

```javascript
const formatDate = (timestamp) => {
  if (!timestamp) return 'Unknown';
  
  // Handle Firestore timestamp objects
  const date = timestamp.toDate ? timestamp.toDate() : new Date(timestamp);
  
  // Check if date is valid
  if (isNaN(date.getTime())) {
    return 'Invalid Date';
  }
  
  // ... rest of the date formatting logic
};
```

### ✨ Key Improvements
- ✅ **Firestore Compatibility**: Uses `timestamp.toDate()` for Firestore timestamp objects
- ✅ **Backward Compatibility**: Falls back to `new Date(timestamp)` for regular date strings
- ✅ **Error Handling**: Validates dates and shows 'Invalid Date' if parsing fails
- ✅ **Null Safety**: Returns 'Unknown' for null/undefined timestamps

### 📋 Expected Results
Roadmap cards will now display proper creation dates:
- "Today" (for roadmaps created today)
- "Yesterday" (for roadmaps created yesterday)
- "3 days ago" (for roadmaps created within the last week)
- "12/5/2024" (for older roadmaps)

### 🧪 Testing
- ✅ Build passes successfully
- ✅ No breaking changes
- ✅ Maintains existing date formatting behavior

### 🔗 Related
This is a follow-up fix to PR #2 which implemented the Firestore integration but missed updating the date formatting function to handle Firestore timestamps properly.

---

Fixes the "Invalid Date" display issue in roadmap cards.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author