### PR TITLE
Add visual privacy indicators to roadmap cards

### DIFF
--- a/src/components/roadmap/PrivacyIndicator.jsx
+++ b/src/components/roadmap/PrivacyIndicator.jsx
@@ -1,0 +1,68 @@
+import Tooltip from "../tooltips/Tooltip";
+
+const PrivacyIndicator = ({ isPublic, size = "sm", showLabel = false, className = "" }) => {
+  const sizeClasses = {
+    xs: "w-3 h-3",
+    sm: "w-4 h-4", 
+    md: "w-5 h-5",
+    lg: "w-6 h-6"
+  };
+
+  const iconSize = sizeClasses[size] || sizeClasses.sm;
+
+  const PrivateIcon = () => (
+    <svg
+      className={`${iconSize} text-gray-600 dark:text-gray-400`}
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+        d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+      />
+    </svg>
+  );
+
+  const PublicIcon = () => (
+    <svg
+      className={`${iconSize} text-green-600 dark:text-green-400`}
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+        d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+    </svg>
+  );
+
+  const tooltipContent = isPublic 
+    ? "Public roadmap - visible to everyone and appears in public listings"
+    : "Private roadmap - only visible to you";
+
+  const labelText = isPublic ? "Public" : "Private";
+  const labelClasses = isPublic 
+    ? "text-green-600 dark:text-green-400" 
+    : "text-gray-600 dark:text-gray-400";
+
+  return (
+    <Tooltip content={tooltipContent} position="top" maxWidth="250px">
+      <div className={`flex items-center space-x-1 ${className}`}>
+        {isPublic ? <PublicIcon /> : <PrivateIcon />}
+        {showLabel && (
+          <span className={`text-xs font-medium ${labelClasses}`}>
+            {labelText}
+          </span>
+        )}
+      </div>
+    </Tooltip>
+  );
+};
+
+export default PrivacyIndicator;

--- a/src/components/roadmap/PublicRoadmapsList.jsx
+++ b/src/components/roadmap/PublicRoadmapsList.jsx
@@ -7,6 +7,7 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useFirestore } from '../../context/FirestoreContext';
 import Tooltip from '../tooltips/Tooltip';
+import PrivacyIndicator from './PrivacyIndicator';
 
 const PublicRoadmapsList = () => {
   const { publicRoadmaps, loading, error } = useFirestore();
@@ -141,9 +142,17 @@ const PublicRoadmapsList = () => {
               >
                 <div className="bg-gray-50 dark:bg-gray-700 rounded-lg p-4 border border-gray-200 dark:border-gray-600 hover:border-blue-300 dark:hover:border-blue-600 transition-colors duration-200">
                   <div className="flex items-start justify-between mb-3">
-                    <h3 className="font-medium text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 line-clamp-2">
-                      {roadmap.title}
-                    </h3>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center space-x-2 mb-1">
+                        <h3 className="font-medium text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 line-clamp-2">
+                          {roadmap.title}
+                        </h3>
+                        <PrivacyIndicator
+                          isPublic={true}
+                          size="xs"
+                        />
+                      </div>
+                    </div>
                     <span className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium ${getDifficultyColor(roadmap.projectLevel)}`}>
                       {roadmap.projectLevel}
                     </span>
@@ -199,6 +208,10 @@ const PublicRoadmapsList = () => {
                         <h3 className="font-medium text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 truncate">
                           {roadmap.title}
                         </h3>
+                        <PrivacyIndicator
+                          isPublic={true}
+                          size="xs"
+                        />
                         <span className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium ${getDifficultyColor(roadmap.projectLevel)}`}>
                           {roadmap.projectLevel}
                         </span>

--- a/src/components/roadmap/RoadmapHistory.jsx
+++ b/src/components/roadmap/RoadmapHistory.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import Tooltip from "../tooltips/Tooltip";
 import { ErrorTooltip } from "../tooltips/EnhancedTooltip";
+import PrivacyIndicator from "./PrivacyIndicator";
 
 const RoadmapHistory = ({ roadmaps, onSelectRoadmap, onDeleteRoadmap }) => {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(null);
@@ -128,10 +129,16 @@ const RoadmapHistory = ({ roadmaps, onSelectRoadmap, onDeleteRoadmap }) => {
               {/* Header */}
               <div className="flex items-start justify-between mb-3">
                 <div className="flex-1 min-w-0">
-                  <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
-                    {roadmap.title}
-                  </h3>
-                  <p className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+                  <div className="flex items-center space-x-2 mb-1">
+                    <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
+                      {roadmap.title}
+                    </h3>
+                    <PrivacyIndicator
+                      isPublic={roadmap.isPublic}
+                      size="xs"
+                    />
+                  </div>
+                  <p className="text-xs text-gray-600 dark:text-gray-400">
                     {formatDate(roadmap.createdAt)}
                   </p>
                 </div>


### PR DESCRIPTION
## 🔒 Privacy Indicators for Roadmap Cards

This PR adds visual indicators to show whether roadmap cards are public or private, improving user experience and clarity.

### ✨ Features Added

- **New PrivacyIndicator Component**: Reusable component with professional SVG icons
- **My Roadmaps Privacy Indicators**: Shows lock icon for private roadmaps, globe icon for public ones
- **Public Roadmaps Consistency**: Adds public indicators to community roadmaps for visual consistency
- **Accessibility**: Includes tooltips explaining privacy status
- **Responsive Design**: Multiple size options (xs, sm, md, lg) and optional labels

### 🎨 Design Details

- **Private Icon**: Lock icon in gray color (`text-gray-600 dark:text-gray-400`)
- **Public Icon**: Globe icon in green color (`text-green-600 dark:text-green-400`)
- **Positioning**: Icons appear next to roadmap titles in both grid and list views
- **Tooltips**: Descriptive tooltips explain privacy implications
- **Consistent Styling**: Follows existing Tailwind CSS patterns

### 📁 Files Modified

1. **`src/components/roadmap/PrivacyIndicator.jsx`** (NEW)
   - Reusable privacy indicator component
   - SVG icons for private/public status
   - Configurable sizes and optional labels
   - Accessibility-compliant tooltips

2. **`src/components/roadmap/RoadmapHistory.jsx`**
   - Added privacy indicators to "My Roadmaps" cards
   - Shows actual privacy status from roadmap metadata
   - Positioned next to roadmap titles

3. **`src/components/roadmap/PublicRoadmapsList.jsx`**
   - Added public indicators to community roadmaps
   - Maintains visual consistency across the app
   - Applied to both grid and list view modes

### 🔍 Implementation Details

- Uses `roadmap.isPublic` boolean from Firestore metadata
- Icons are sized appropriately for card layouts (xs size)
- Tooltips provide clear explanations of privacy implications
- No breaking changes to existing functionality
- Follows user's preferred professional styling patterns

### 🧪 Testing

- [x] Privacy indicators appear on My Roadmaps cards
- [x] Public indicators appear on Community Roadmaps cards
- [x] Tooltips work correctly and are accessible
- [x] Icons scale properly in different view modes
- [x] Dark mode styling works correctly
- [x] No layout disruption to existing cards

### 📱 Screenshots

*Privacy indicators will show:*
- 🔒 Lock icon for private roadmaps (gray)
- 🌐 Globe icon for public roadmaps (green)
- Tooltips explaining privacy status on hover

This enhancement provides immediate visual feedback about roadmap privacy status, helping users understand which roadmaps are shared publicly and which remain private.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author